### PR TITLE
Hover highlight background colour to be same as active item

### DIFF
--- a/src/LivewireSelect.php
+++ b/src/LivewireSelect.php
@@ -214,7 +214,7 @@ class LivewireSelect extends Component
             'searchInput' => 'p-2 rounded border w-full rounded',
             'searchOptionsContainer' => 'absolute top-0 left-0 mt-12 w-full z-10',
 
-            'searchOptionItem' => 'p-3 hover:bg-gray-100 cursor-pointer text-sm',
+            'searchOptionItem' => 'p-3 hover:bg-indigo-600 cursor-pointer text-sm',
             'searchOptionItemActive' => 'bg-indigo-600 text-white font-medium',
             'searchOptionItemInactive' => 'bg-white text-gray-600',
 

--- a/src/LivewireSelect.php
+++ b/src/LivewireSelect.php
@@ -214,7 +214,7 @@ class LivewireSelect extends Component
             'searchInput' => 'p-2 rounded border w-full rounded',
             'searchOptionsContainer' => 'absolute top-0 left-0 mt-12 w-full z-10',
 
-            'searchOptionItem' => 'p-3 hover:bg-indigo-600 cursor-pointer text-sm',
+            'searchOptionItem' => 'p-3 cursor-pointer text-sm',
             'searchOptionItemActive' => 'bg-indigo-600 text-white font-medium',
             'searchOptionItemInactive' => 'bg-white text-gray-600',
 


### PR DESCRIPTION
Currently when your mouse hover over over the search item dropdown. It is bg-gray-100. While at the same time the text is white (text-white).

This makes it really hard to see.

This PR try to fix that