### PR TITLE
Match PHP minimum to laravel 7 minimum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2.5",
         "illuminate/support": "^6.0|^7.0",
         "livewire/livewire": "^1.1"
     },


### PR DESCRIPTION
Laravel 7 requires at least PHP 7.2.5 so setting it to at least too that since this package minimum laravel version is 7.