### PR TITLE
WIP: Maintain an id that can be linked by a label

### DIFF
--- a/resources/views/search-selected-option.blade.php
+++ b/resources/views/search-selected-option.blade.php
@@ -1,5 +1,5 @@
 <button
-    id="{{ $name }}-selected"
+    id="{{ $name }}"
     type="button"
     class="{{ $styles['searchSelectedOption'] }}"
 


### PR DESCRIPTION
I couldn't find anywhere that the id `{{ $name }}-selected` was being used, so this shouldn't break anything.
It's good for a label to still be able to reference the "input".