### PR TITLE
fix cascading livewire select inputs nulled after repainting

### DIFF
--- a/resources/views/select.blade.php
+++ b/resources/views/select.blade.php
@@ -1,6 +1,6 @@
 <div>
 
-    <div>
+    <div x-init="$wire.set('value', {{ $initValueEncoded }})">
         @if(!$searchable && $shouldShow)
             @include($defaultView, [
                 'name' => $name,

--- a/src/LivewireSelect.php
+++ b/src/LivewireSelect.php
@@ -32,6 +32,7 @@ class LivewireSelect extends Component
     public $placeholder;
 
     public $value;
+    public $initValueEncoded;
     public $optionsValues;
 
     public $searchable;
@@ -75,6 +76,7 @@ class LivewireSelect extends Component
         $this->placeholder = $placeholder;
 
         $this->value = $value;
+        $this->initValueEncoded = json_encode($value);
 
         $this->searchable = $searchable;
         $this->searchTerm = '';
@@ -119,7 +121,7 @@ class LivewireSelect extends Component
 
     public function selectedOption($value)
     {
-        return null;
+        return $value;
     }
 
     public function notifyValueChanged()
@@ -248,6 +250,7 @@ class LivewireSelect extends Component
 
         return view($this->selectView)
             ->with([
+                'initValueEncoded' => $this->initValueEncoded,
                 'options' => $options,
                 'selectedOption' => $selectedOption ?? null,
                 'shouldShow' => $shouldShow,


### PR DESCRIPTION
### The Problem:

As mentioned in #18 currently while executing the render method all livewire-select component values, which have dependencies, are nulled.

Assuming the following components the `car-brand-select` would indeed show up with the right (visible) value, but `car-model-select` would not only have no value, but it would also have no options (because  `car-brand-select` value is actually `null`)

```blade
<livewire:car-brand-select
   name="car_brand_id"
   :value="$initialValue" // optional
   placeholder="Choose a Car Brand" // optional
/>

<livewire:car-model-select
    name="car_model_id"
    placeholder="Choose a Car Model"
    :depends-on="['car_brand_id']"
/>
```

### Solution:

I have added a new property to the livewire component, called `initValueEncoded`, this value is set on mount the same as the `value` prop, but json encoded.

**why json?** Refering to another pull request of mine, it is mandatory that also an array of values can be submitted.

Inside the select.blade.json the `value` Livewire property can now be set during component initialization:
```blade
<div x-init="$wire.set('value', {{ $initValueEncoded }})">
```

(closes #18)